### PR TITLE
Add explicit client IDs to auth tokens

### DIFF
--- a/pkg/httphandler/middleware/auth.go
+++ b/pkg/httphandler/middleware/auth.go
@@ -100,7 +100,14 @@ func ParseAuthMap(tokenConfig string) (AuthMap, error) {
 
 	tokenDefs := strings.Split(tokenConfig, ",")
 	authMap := make(map[string]string, len(tokenDefs)) // mapping from token value to client ID
-	for _, tokenDef := range tokenDefs {
+	for idx, tokenDef := range tokenDefs {
+		// TODO: drop this backwards-compat code after migrating to new token
+		// format.
+		if !strings.Contains(tokenDef, ":") {
+			authMap[strings.TrimSpace(tokenDef)] = fmt.Sprintf("client-%d", idx)
+			continue
+		}
+
 		parts := strings.SplitN(tokenDef, ":", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf(`invalid token format %q, token must be in "client-id:token-value" format`, tokenDef)

--- a/pkg/httphandler/middleware/auth.go
+++ b/pkg/httphandler/middleware/auth.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"crypto/sha1"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,12 +9,13 @@ import (
 	"github.com/honeycombio/beeline-go"
 )
 
-func authHandler(next http.Handler, authTokens []string) http.Handler {
-	authTokenMap := stringSliceToMap(authTokens)
+// AuthMap maps from opaque token value to client ID.
+type AuthMap map[string]string
 
+func authHandler(next http.Handler, authMap AuthMap) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		clientID, err := authenticate(r, authTokenMap)
+		clientID, err := authenticate(r, authMap)
 		if err != nil {
 			beeline.AddField(ctx, "client_authenticated", false)
 			beeline.AddField(ctx, "error", err)
@@ -31,7 +31,7 @@ func authHandler(next http.Handler, authTokens []string) http.Handler {
 	})
 }
 
-func authenticate(r *http.Request, authTokenMap map[string]struct{}) (string, error) {
+func authenticate(r *http.Request, authMap AuthMap) (string, error) {
 	tok, err := authTokenFromRequest(r)
 	if err != nil {
 		beeline.AddField(r.Context(), "auth_result", "error")
@@ -39,20 +39,16 @@ func authenticate(r *http.Request, authTokenMap map[string]struct{}) (string, er
 	}
 
 	authProvided := tok != ""
-	_, authValid := authTokenMap[tok]
+	clientID, authValid := authMap[tok]
 
 	switch {
 	case authValid:
-		return authTokenToClientID(tok), nil
+		return clientID, nil
 	case !authProvided:
 		return "", nil
 	default:
 		return "", errInvalidAuthToken
 	}
-}
-
-func authTokenToClientID(tok string) string {
-	return fmt.Sprintf("%x", sha1.Sum([]byte(tok)))
 }
 
 type clientIDKeyType int
@@ -95,13 +91,34 @@ func sendAuthError(w http.ResponseWriter) {
 	_, _ = w.Write([]byte(`{"error": "unauthorized"}`))
 }
 
-func stringSliceToMap(xs []string) map[string]struct{} {
-	m := make(map[string]struct{}, len(xs))
-	for _, k := range xs {
-		k = strings.TrimSpace(k)
-		if k != "" {
-			m[k] = struct{}{}
-		}
+// ParseAuthMap takes a slice of token strings in "client-id:token-value"
+// form and returns a mapping from token value to client ID.
+func ParseAuthMap(tokenConfig string) (AuthMap, error) {
+	if len(strings.TrimSpace(tokenConfig)) == 0 {
+		return nil, nil
 	}
-	return m
+
+	tokenDefs := strings.Split(tokenConfig, ",")
+	authMap := make(map[string]string, len(tokenDefs)) // mapping from token value to client ID
+	for _, tokenDef := range tokenDefs {
+		parts := strings.SplitN(tokenDef, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf(`invalid token format %q, token must be in "client-id:token-value" format`, tokenDef)
+		}
+		clientID := strings.TrimSpace(parts[0])
+		token := strings.TrimSpace(parts[1])
+		if clientID == "" {
+			return nil, fmt.Errorf("auth token %q has empty client ID", tokenDef)
+		}
+		if token == "" || strings.Contains(token, " ") {
+			return nil, fmt.Errorf("auth token value in %q cannot be empty or contain spaces", tokenDef)
+		}
+		if _, found := authMap[token]; found {
+			return nil, fmt.Errorf("duplicate auth token value %q", token)
+		}
+
+		authMap[token] = clientID
+	}
+
+	return authMap, nil
 }

--- a/pkg/httphandler/middleware/auth_test.go
+++ b/pkg/httphandler/middleware/auth_test.go
@@ -108,10 +108,21 @@ func TestParseAuthMap(t *testing.T) {
 			input:   "client-1:foo bar",
 			wantErr: errors.New("auth token value in \"client-1:foo bar\" cannot be empty or contain spaces"),
 		},
-		"invalid token format": {
-			input:   "client-1/token-1",
-			wantErr: errors.New("invalid token format \"client-1/token-1\", token must be in \"client-id:token-value\" format"),
+
+		// TODO: Drop this test case and restore the following test case once
+		// token migration is done.
+		"temporary backwards-compatible token parsing": {
+			input: "token-1,token-2,real-client:token-3",
+			want: AuthMap{
+				"token-1": "client-0",
+				"token-2": "client-1",
+				"token-3": "real-client",
+			},
 		},
+		// "invalid token format": {
+		// 	input:   "client-1/token-1",
+		// 	wantErr: errors.New("invalid token format \"client-1/token-1\", token must be in \"client-id:token-value\" format"),
+		// },
 	}
 
 	for name, tc := range testCases {

--- a/pkg/httphandler/middleware/middleware.go
+++ b/pkg/httphandler/middleware/middleware.go
@@ -15,9 +15,9 @@ import (
 
 // Wrap wraps an http handler with middleware to add instrumentation, error
 // handling, authentication, and rate limiting.
-func Wrap(h http.Handler, authTokens []string, rl *rate.Limiter, l zerolog.Logger) http.Handler {
+func Wrap(h http.Handler, authMap AuthMap, rl *rate.Limiter, l zerolog.Logger) http.Handler {
 	h = rateLimitHandler(h, rl)
-	h = authHandler(h, authTokens)
+	h = authHandler(h, authMap)
 	h = panicHandler(h)
 	h = observeHandler(h, l)
 	h = hnynethttp.WrapHandler(h)

--- a/pkg/httphandler/middleware/ratelimiter_test.go
+++ b/pkg/httphandler/middleware/ratelimiter_test.go
@@ -12,7 +12,10 @@ import (
 func TestRateLimiter(t *testing.T) {
 	t.Parallel()
 
-	authTokens := []string{"valid-token"}
+	authMap := map[string]string{
+		"valid-token": "client-1",
+	}
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
@@ -49,7 +52,7 @@ func TestRateLimiter(t *testing.T) {
 			srv := httptest.NewServer(
 				authHandler(
 					rateLimitHandler(handler, tc.rl),
-					authTokens,
+					authMap,
 				),
 			)
 


### PR DESCRIPTION
A slight expansion to the minimal approach to auth that decouples client IDs from token values, allowing for token rotation and stable client IDs in telemetry.