### PR TITLE
Log client IDs & drop backwards-compat code

### DIFF
--- a/cmd/urlresolverapi/main.go
+++ b/cmd/urlresolverapi/main.go
@@ -61,7 +61,7 @@ func main() {
 
 		honeycombAPIKey      = fs.String("honeycomb-api-key", "", "Honeycomb API key (enables sending telemetry data to honeycomb)")
 		honeycombDataset     = fs.String("honeycomb-dataset", "urlresolverapi", "Honeycomb dataset for telemetry data")
-		honeycombServiceName = fs.String("honeycomb-service-name", "urlresolverapi", "Service name for telemetry data") // TODO: stop relying on fly.io specifics
+		honeycombServiceName = fs.String("honeycomb-service-name", "urlresolverapi", "Service name for telemetry data")
 		honeycombSampleRate  = fs.Uint("honeycomb-sample-rate", 1, "Sample rate for telemetry data (1/N events will be submitted)")
 
 		transportIdleConnTTL         = fs.Duration("idle-cx-ttl", 90*time.Second, "TTL for idle connections")

--- a/pkg/httphandler/middleware/auth.go
+++ b/pkg/httphandler/middleware/auth.go
@@ -30,7 +30,7 @@ func authHandler(next http.Handler, authMap AuthMap) http.Handler {
 
 		beeline.AddField(ctx, "client_authenticated", clientID != "")
 		beeline.AddField(ctx, "client_id", clientID)
-		d.Set("client_id", clientID)
+		_ = d.Set("client_id", clientID)
 
 		r = r.WithContext(contextWithClientID(r.Context(), clientID))
 		next.ServeHTTP(w, r)

--- a/pkg/httphandler/middleware/auth_test.go
+++ b/pkg/httphandler/middleware/auth_test.go
@@ -108,21 +108,10 @@ func TestParseAuthMap(t *testing.T) {
 			input:   "client-1:foo bar",
 			wantErr: errors.New("auth token value in \"client-1:foo bar\" cannot be empty or contain spaces"),
 		},
-
-		// TODO: Drop this test case and restore the following test case once
-		// token migration is done.
-		"temporary backwards-compatible token parsing": {
-			input: "token-1,token-2,real-client:token-3",
-			want: AuthMap{
-				"token-1": "client-0",
-				"token-2": "client-1",
-				"token-3": "real-client",
-			},
+		"invalid token format": {
+			input:   "client-1/token-1",
+			wantErr: errors.New("invalid token format \"client-1/token-1\", token must be in \"client-id:token-value\" format"),
 		},
-		// "invalid token format": {
-		// 	input:   "client-1/token-1",
-		// 	wantErr: errors.New("invalid token format \"client-1/token-1\", token must be in \"client-id:token-value\" format"),
-		// },
 	}
 
 	for name, tc := range testCases {

--- a/pkg/httphandler/middleware/middleware.go
+++ b/pkg/httphandler/middleware/middleware.go
@@ -30,6 +30,7 @@ func observeHandler(next http.Handler, l zerolog.Logger) http.Handler {
 		m := httpsnoop.CaptureMetrics(next, w, r.WithContext(ctx))
 
 		rec := logRecord{
+			ClientID:   d.GetString("client_id"),
 			DurationMS: m.Duration.Milliseconds(),
 			Method:     r.Method,
 			RemoteAddr: getRemoteAddr(r),
@@ -84,6 +85,7 @@ func getRemoteAddr(r *http.Request) string {
 }
 
 type logRecord struct {
+	ClientID   string `json:"client_id"`
 	DurationMS int64  `json:"duration_ms"`
 	Method     string `json:"method"`
 	RemoteAddr string `json:"remote_addr"`
@@ -105,6 +107,7 @@ func (rec logRecord) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("remote_addr", rec.RemoteAddr)
 	e.Str("url", rec.URL)
 	e.Str("user_agent", rec.UserAgent)
+	e.Str("client_id", rec.ClientID)
 	if rec.Error != "" {
 		e.Str("error", rec.Error)
 		if rec.Stack != "" {


### PR DESCRIPTION
Quick follow-up to #8, dropping backwards-compat code after token migration and adding client ID to logs.