### PR TITLE
Include Intermediate URLs in API response

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1-experimental
-FROM golang:1.16
+FROM golang:1.17
 
 WORKDIR /go/src/app
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,26 @@ query parameters, and attempting to fetch its title.
 It is used by [Thresholderbot][] to resolve URLs found in tweets, which tend to
 be wrapped in one or more URL shorteners (t.co, bit.ly, etc).
 
+A publicly-available instance is available at https://api.urlresolver.com,
+(deployed on [fly.io](https://fly.io)).
+
 ## API
 
 There is a single API endpoint, `/resolve`, seen here resolving a t.co URL that redirects a
 few times before ending up at the New York Times:
 
 ```
-GET /resolve?url=https://t.co/1AuEh8FMK0?amp=1
+GET https://api.urlresolver.com/resolve?url=https://t.co/1AuEh8FMK0?amp=1
 
 {
   "given_url": "https://t.co/1AuEh8FMK0?amp=1",
   "resolved_url": "https://www.nytimes.com/2021/08/25/style/lil-nas-x.html",
-  "title": "Some Said Lil Nas X Was a One-Hit Wonder. They Were Wrong. - The New York Times"
+  "title": "Some Said Lil Nas X Was a One-Hit Wonder. They Were Wrong. - The New York Times",
+  "intermediate_urls": [
+    "https://t.co/1AuEh8FMK0?amp=1",
+    "https://nyti.ms/3BlpRIR",
+    "https://trib.al/4OR3gtI"
+  ]
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,12 @@ require (
 	github.com/go-redis/cache/v8 v8.4.0
 	github.com/go-redis/redis/v8 v8.8.2
 	github.com/honeycombio/beeline-go v1.1.0
-	github.com/mccutchen/urlresolver v0.1.1
+	github.com/mccutchen/urlresolver v0.1.2
 	github.com/peterbourgon/ctxdata/v4 v4.0.0
 	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/rs/zerolog v1.21.0
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect
+	golang.org/x/net v0.0.0-20210902165921-8d991716f632 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 )

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mccutchen/urlresolver v0.1.1 h1:Ox88br8MgwV6s+7GwLfknV2L8xMsXJ2zSJXMVUcpS84=
-github.com/mccutchen/urlresolver v0.1.1/go.mod h1:Pq2bjZsoanMS2WyrhGJ+efxyX/qilqDl7RtzIgZOBmY=
+github.com/mccutchen/urlresolver v0.1.2 h1:xgqNXTR//8IItwyNfsNScIuwZIgjDFoqznJuCXpccI0=
+github.com/mccutchen/urlresolver v0.1.2/go.mod h1:Pq2bjZsoanMS2WyrhGJ+efxyX/qilqDl7RtzIgZOBmY=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -412,8 +412,8 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210902165921-8d991716f632 h1:900XJE4Rn/iPU+xD5ZznOe4GKKc4AdFK0IO1P6Z3/lQ=
+golang.org/x/net v0.0.0-20210902165921-8d991716f632/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -458,8 +458,9 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 h1:Vv0JUPWTyeqUq42B2WJ1FeIDjjvGKoA2Ss+Ts0lAVbs=

--- a/pkg/httphandler/httphandler.go
+++ b/pkg/httphandler/httphandler.go
@@ -168,7 +168,9 @@ func sendJSON(w http.ResponseWriter, code int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", cacheControlValue(code))
 	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(data)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(data)
 }
 
 func sendError(w http.ResponseWriter, msg string, code int) {


### PR DESCRIPTION
Pick up https://github.com/mccutchen/urlresolver/pull/16 to include intermediate URLs in API response, plus
- upgrade to go 1.17
- pretty-print JSON