### PR TITLE
Drop test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,23 +6,19 @@ on:
   pull_request:
     branches: [main] # pull requests AGAINST main
 
+env:
+  GO_VERSION: '1.18'
+
 jobs:
   test:
     name: test
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        go-version:
-        - '1.17'
-        - '1.16'
-        - '1.15'
-
     steps:
     - name: setup
       uses: actions/setup-go@v2
       with:
-        go-version: ${{matrix.go-version}}
+        go-version: ${{env.GO_VERSION}}
 
     - name: checkout
       uses: actions/checkout@v2
@@ -36,13 +32,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-build-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-build-${{ hashFiles('**/go.sum') }}
 
     - name: cache mod
       uses: actions/cache@v2
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-mod-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-${{ hashFiles('**/go.sum') }}
 
     - name: build
       run: make build
@@ -54,4 +50,3 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.out
-      if: ${{ matrix.go-version == '1.17' }}


### PR DESCRIPTION
This isn't a library that folks will be running against many different go versions, it's a deployable HTTP server. Fine to save time, energy, and (Microsoft's) money by testing against only one version.