### PR TITLE
build: fix docker build on remote fly.io builders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
 COPY . .
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
-    BUILD_ARGS='-mod=readonly -ldflags="-s -w"' \
+    BUILD_ARGS='-mod=readonly -ldflags="-s -w" -buildvcs=false' \
     DIST_PATH=/bin \
     make
 


### PR DESCRIPTION
Without this change, using a remote builder when deploying to fly.io consistently fails with this error:

```
=> ERROR [stage-0 6/6] RUN --mount=type=cache,id=gomod,target=/go/pkg/mod     --mount=type=cache,id=gobuild,target=/root/.cache/go-build     BUILD_ARGS='-mod=readonly -ldflags="-s -w"'     DIST_PATH=/  0.6s
------
 > [stage-0 6/6] RUN --mount=type=cache,id=gomod,target=/go/pkg/mod     --mount=type=cache,id=gobuild,target=/root/.cache/go-build     BUILD_ARGS='-mod=readonly -ldflags="-s -w"'     DIST_PATH=/bin     make:
#13 0.304 mkdir -p /bin
#13 0.305 CGO_ENABLED=0 go build -mod=readonly -ldflags="-s -w" -o /bin/urlresolverapi ./cmd/urlresolverapi
#13 0.528 error obtaining VCS status: exit status 128
#13 0.528 	Use -buildvcs=false to disable VCS stamping.
#13 0.530 make: *** [Makefile:29: /bin/urlresolverapi] Error 1
------
Error failed to fetch an image or build from source: error building: executor failed running [/bin/sh -c BUILD_ARGS='-mod=readonly -ldflags="-s -w"'     DIST_PATH=/bin     make]: exit code: 2
```

We don't really need or care about VCS info in the built binaries deployed to that platform, so there's no harm in adding this flag.