### PR TITLE
build: simplify CI setup

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v3
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,47 +11,33 @@ concurrency:
   group: "test-${{ github.ref }}"
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-env:
-  GO_VERSION: '1.20'
-
 jobs:
   test:
     name: test
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        # build against the two latest releases, to match golang's release
+        # policy: https://go.dev/doc/devel/release#policy
+        go-version:
+        - 'stable'
+        - 'oldstable'
+
     steps:
     - name: setup
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: ${{env.GO_VERSION}}
+        go-version: ${{matrix.go-version}}
 
     - name: checkout
-      uses: actions/checkout@v2
-
-    - id: go-cache-paths
-      run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
-
-    - name: cache build
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-build-${{ hashFiles('**/go.sum') }}
-
-    - name: cache mod
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-mod-${{ hashFiles('**/go.sum') }}
-
-    - name: build
-      run: make build
+      uses: actions/checkout@v4
 
     - name: test
       run: make testci
 
-    - name: code coverage
-      uses: codecov/codecov-action@v1
+    - name: report code coverage
+      uses: codecov/codecov-action@v3
       with:
-        file: ./coverage.out
+        files: ./coverage.out
+      if: ${{ matrix.go-version == 'stable' }}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/mccutchen/urlresolverapi
 
 go 1.21
 
-toolchain go1.21.5
-
 require (
 	github.com/alicebob/miniredis/v2 v2.14.3
 	github.com/felixge/httpsnoop v1.0.3


### PR DESCRIPTION
Test against the two most recent stable golang versions, matching [the golang release policy](https://go.dev/doc/devel/release#policy).

Ported over from https://github.com/mccutchen/urlresolver/pull/28.